### PR TITLE
Mount DevToolsView on a separate node

### DIFF
--- a/src/entry-points/client.js
+++ b/src/entry-points/client.js
@@ -52,24 +52,24 @@ match({ routes: createRoutes(instanceStore), location: requestUrl, basename: win
     </Router>
   );
 
-  let node;
-  if (__DEBUG__ && !window.devToolsExtension) {
-    const DevToolsView = require('../components/DevToolsView').default;
-    // Enable Redux dev tools in DEBUG mode
-    node = (
-      <Provider store={instanceStore.store}>
-        <div>
-          {routerInst}
-          <DevToolsView/>
-        </div>
-      </Provider>
-    );
-  } else {
-    node = (
-      <Provider store={instanceStore.store}>
-        {routerInst}
-      </Provider>
-    );
-  }
+  const node = (
+    <Provider store={instanceStore.store}>
+      {routerInst}
+    </Provider>
+  );
+
   ReactDOM.render(node, target);
+
+  if (__DEBUG__ && !window.devToolsExtension) {
+    // Enable Redux dev tools in DEBUG mode
+    const DevToolsView = require('../components/DevToolsView').default;
+    const devNode = (
+      <Provider store={instanceStore.store}>
+        <DevToolsView/>
+      </Provider>
+    );
+    const devTarget = document.createElement('div');
+    target.parentNode.insertBefore(devTarget, target.nextSibling);
+    ReactDOM.render(devNode, devTarget);
+  }
 });


### PR DESCRIPTION
Hey @slavb18

Thanks for this awesome boilerplate.
One thing I did notice, is that ssr doesn't work well, if the `DevToolsView` is mounted in the `<div id="root"></div>`. This will cause the checksums between server and client to mismatch.

    Warning: React attempted to reuse markup in a container but the checksum was invalid. This generally means that you are using server rendering and the markup generated on the server was not what the client was expecting. React injected new markup to compensate which works but you have lost many of the benefits of server rendering. Instead, figure out why the markup being generated is different on the client or server:
     (client) <div data-reactid=".2560i
     (server) <div class="index---w---3

More info: https://github.com/reactjs/react-router-redux/issues/36

This PR should solve the problem.